### PR TITLE
문제 api 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,8 @@ dependencies {
     /* ====== Test Dependencies ====== */
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
 }
 
 def querydslDir = "$buildDir/generated/querydsl"

--- a/src/main/java/Coding_GO/codingGO/CodingGoApplication.java
+++ b/src/main/java/Coding_GO/codingGO/CodingGoApplication.java
@@ -2,7 +2,9 @@ package Coding_GO.codingGO;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class CodingGoApplication {
 

--- a/src/main/java/Coding_GO/codingGO/domain/problem/data/SolvedAcProblemDto.java
+++ b/src/main/java/Coding_GO/codingGO/domain/problem/data/SolvedAcProblemDto.java
@@ -1,0 +1,36 @@
+package Coding_GO.codingGO.domain.problem.data;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SolvedAcProblemDto {
+    @JsonProperty("problemId")
+    private Integer id;
+
+    @JsonProperty("titleKo")
+    private String title;
+
+    private int level; // 난이도 수치
+    private int solvedCount; // 푼 사람 수
+
+    private List<TagDto> tags; // 알고리즘 태그 리스트
+
+    @Data
+    public static class TagDto {
+        private String key; // 태그 이름 (예: greedy, dp)
+    }
+
+    // 태그 리스트를 문자열 하나로 합치는 편의 메서드
+    public String getTagsAsString() {
+        if (tags == null || tags.isEmpty()) return "";
+        return tags.stream()
+                .map(TagDto::getKey)
+                .collect(Collectors.joining(", "));
+    }
+}

--- a/src/main/java/Coding_GO/codingGO/domain/problem/data/Tier.java
+++ b/src/main/java/Coding_GO/codingGO/domain/problem/data/Tier.java
@@ -1,0 +1,30 @@
+package Coding_GO.codingGO.domain.problem.data;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Arrays;
+import java.util.Comparator;
+
+@Getter
+@AllArgsConstructor
+public enum Tier {
+    UNRATED(0,"Unrated"),
+    BRONZE(1,"Bronze"),
+    SILVER(6,"Silver"),
+    GOLD(11,"Gold"),
+    PLATINUM(16,"Platinum"),
+    DIAMOND(21,"Diamond"),
+    RUBY(26, "Ruby");
+
+    private final int startLevel;
+    private final String name;
+
+    public static String getDescription(int level){
+        if (level ==0) return UNRATED.name;
+        Tier tier = Arrays.stream(values()).filter(t -> level >= t.startLevel)
+                .max(Comparator.comparingInt(Tier::getStartLevel)).orElse(UNRATED);
+        int detail = 5 - ((level - tier.startLevel) % 5);
+        return tier.name + " " + detail;
+    }
+}

--- a/src/main/java/Coding_GO/codingGO/domain/problem/data/Tier.java
+++ b/src/main/java/Coding_GO/codingGO/domain/problem/data/Tier.java
@@ -9,22 +9,19 @@ import java.util.Comparator;
 @Getter
 @AllArgsConstructor
 public enum Tier {
-    UNRATED(0,"Unrated"),
-    BRONZE(1,"Bronze"),
-    SILVER(6,"Silver"),
-    GOLD(11,"Gold"),
-    PLATINUM(16,"Platinum"),
-    DIAMOND(21,"Diamond"),
-    RUBY(26, "Ruby");
+    UNRANKED("Unranked"),
+    BRONZE_V("Bronze V"), BRONZE_IV("Bronze IV"), BRONZE_III("Bronze III"), BRONZE_II("Bronze II"), BRONZE_I("Bronze I"),
+    SILVER_V("Silver V"), SILVER_IV("Silver IV"), SILVER_III("Silver III"), SILVER_II("Silver II"), SILVER_I("Silver I"),
+    GOLD_V("Gold V"), GOLD_IV("Gold IV"), GOLD_III("Gold III"), GOLD_II("Gold II"), GOLD_I("Gold I"),
+    PLATINUM_V("Platinum V"), PLATINUM_IV("Platinum IV"), PLATINUM_III("Platinum III"), PLATINUM_II("Platinum II"), PLATINUM_I("Platinum I"),
+    DIAMOND_V("Diamond V"), DIAMOND_IV("Diamond IV"), DIAMOND_III("Diamond III"), DIAMOND_II("Diamond II"), DIAMOND_I("Diamond I"),
+    RUBY_V("Ruby V"), RUBY_IV("Ruby IV"), RUBY_III("Ruby III"), RUBY_II("Ruby II"), RUBY_I("Ruby I"),
+    MASTER("Master");
 
-    private final int startLevel;
-    private final String name;
+    private final String description;
 
-    public static String getDescription(int level){
-        if (level ==0) return UNRATED.name;
-        Tier tier = Arrays.stream(values()).filter(t -> level >= t.startLevel)
-                .max(Comparator.comparingInt(Tier::getStartLevel)).orElse(UNRATED);
-        int detail = 5 - ((level - tier.startLevel) % 5);
-        return tier.name + " " + detail;
+    public static Tier fromLevel(int level) {
+        if (level < 0 || level >= values().length) return UNRANKED;
+        return values()[level];
     }
 }

--- a/src/main/java/Coding_GO/codingGO/domain/problem/entity/ProblemEntity.java
+++ b/src/main/java/Coding_GO/codingGO/domain/problem/entity/ProblemEntity.java
@@ -1,0 +1,36 @@
+package Coding_GO.codingGO.domain.problem.entity;
+
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@Table(name = "problem")
+@NoArgsConstructor
+@Builder
+@AllArgsConstructor
+public class ProblemEntity {
+    @Id
+    @Column(name = "problem_id")
+    private Integer problemId;
+
+    @Column(nullable = false, length = 255)
+    private String title;
+
+    @Column(nullable = false, length = 255)
+    private String tier;
+
+    @Column(name = "difficulty" , nullable = false)
+    private Integer difficulty;
+
+    @Column(name = "solved_count", nullable = false)
+    private Integer solvedCount;
+
+    @Column(columnDefinition = "TEXT")
+    private String tag;
+}

--- a/src/main/java/Coding_GO/codingGO/domain/problem/presentation/controller/ProblemController.java
+++ b/src/main/java/Coding_GO/codingGO/domain/problem/presentation/controller/ProblemController.java
@@ -12,6 +12,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -49,7 +50,7 @@ public class ProblemController {
             )
     })
     public ResponseEntity<Page<ProblemResponse>> getProblemList(
-            @RequestParam Long userId,
+            @AuthenticationPrincipal Long userId,
             @RequestParam(defaultValue = "1000") int start,
             @RequestParam(defaultValue = "40000") int end,
             @PageableDefault(size = 20) Pageable pageable

--- a/src/main/java/Coding_GO/codingGO/domain/problem/presentation/controller/ProblemController.java
+++ b/src/main/java/Coding_GO/codingGO/domain/problem/presentation/controller/ProblemController.java
@@ -1,0 +1,59 @@
+package Coding_GO.codingGO.domain.problem.presentation.controller;
+
+import Coding_GO.codingGO.domain.problem.presentation.data.response.ProblemResponse;
+import Coding_GO.codingGO.domain.problem.service.ProblemService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("api/CodingGo/problem")
+@RequiredArgsConstructor
+public class ProblemController {
+    private final ProblemService problemService;
+
+    @Operation(
+            summary = "문제 목록 조회 및 실시간 포인트 정산",
+            description = "유저가 접속할 때 백준 풀이 기록을 확인하여 포인트를 지급하고, 최신 문제 목록을 인기순으로 반환합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "조회 및 정산 성공",
+                    content = @Content(schema = @Schema(implementation = ProblemResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 (파라미터 오류)",
+                    content = @Content
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "해당 유저를 찾을 수 없음",
+                    content = @Content
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 또는 외부 API(Solved.ac) 연동 오류",
+                    content = @Content
+            )
+    })
+    public ResponseEntity<Page<ProblemResponse>> getProblemList(
+            @RequestParam Long userId,
+            @RequestParam(defaultValue = "1000") int start,
+            @RequestParam(defaultValue = "40000") int end,
+            @PageableDefault(size = 20) Pageable pageable
+    ){
+        return ResponseEntity.ok(problemService.getProblemList(userId, start, end, pageable));
+    }
+}

--- a/src/main/java/Coding_GO/codingGO/domain/problem/presentation/data/response/ProblemResponse.java
+++ b/src/main/java/Coding_GO/codingGO/domain/problem/presentation/data/response/ProblemResponse.java
@@ -7,7 +7,7 @@ public record ProblemResponse(
         String title,
         String tier,
         int solvedCount,
-        List<String> tags,
+        String tags,
         boolean isSolved,
         Integer rewardPoint
 ) {

--- a/src/main/java/Coding_GO/codingGO/domain/problem/presentation/data/response/ProblemResponse.java
+++ b/src/main/java/Coding_GO/codingGO/domain/problem/presentation/data/response/ProblemResponse.java
@@ -1,0 +1,18 @@
+package Coding_GO.codingGO.domain.problem.presentation.data.response;
+
+import java.util.List;
+
+public record ProblemResponse(
+        Integer problemId,
+        String title,
+        String tier,
+        int solvedCount,
+        List<String> tags,
+        boolean isSolved,
+        Integer rewardPoint
+) {
+
+
+
+
+}

--- a/src/main/java/Coding_GO/codingGO/domain/problem/presentation/data/response/SolvedAcResponseDto.java
+++ b/src/main/java/Coding_GO/codingGO/domain/problem/presentation/data/response/SolvedAcResponseDto.java
@@ -1,0 +1,17 @@
+package Coding_GO.codingGO.domain.problem.presentation.data.response;
+
+import Coding_GO.codingGO.domain.problem.data.SolvedAcProblemDto;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SolvedAcResponseDto {
+    private int count;
+    private List<SolvedAcProblemDto> items;
+}

--- a/src/main/java/Coding_GO/codingGO/domain/problem/repository/ProblemRepository.java
+++ b/src/main/java/Coding_GO/codingGO/domain/problem/repository/ProblemRepository.java
@@ -1,0 +1,8 @@
+package Coding_GO.codingGO.domain.problem.repository;
+
+import Coding_GO.codingGO.domain.problem.entity.ProblemEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.CrudRepository;
+
+public interface ProblemRepository extends JpaRepository<ProblemEntity, Integer>, ProblemRepositoryCustom {
+}

--- a/src/main/java/Coding_GO/codingGO/domain/problem/repository/ProblemRepositoryCustom.java
+++ b/src/main/java/Coding_GO/codingGO/domain/problem/repository/ProblemRepositoryCustom.java
@@ -1,0 +1,9 @@
+package Coding_GO.codingGO.domain.problem.repository;
+
+import Coding_GO.codingGO.domain.problem.presentation.data.response.ProblemResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface ProblemRepositoryCustom {
+    Page<ProblemResponse> findAllWithUserStatus(Long userId, int startId, int endId, Pageable pageable);
+}

--- a/src/main/java/Coding_GO/codingGO/domain/problem/repository/impl/ProblemRepositoryCustomImpl.java
+++ b/src/main/java/Coding_GO/codingGO/domain/problem/repository/impl/ProblemRepositoryCustomImpl.java
@@ -1,0 +1,51 @@
+package Coding_GO.codingGO.domain.problem.repository.impl;
+
+import Coding_GO.codingGO.domain.problem.presentation.data.response.ProblemResponse;
+import Coding_GO.codingGO.domain.problem.repository.ProblemRepositoryCustom;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class ProblemRepositoryCustomImpl implements ProblemRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+
+    @Override
+    public Page<ProblemResponse> findAllWithUserStatus(Long userId, int startId, int endId, Pageable pageable) {
+        QProblemEntity problem = QProblemEntity.problemEntity;
+        QStudyRecordEntity record = QStudyRecordEntity.studyRecordEntity;
+
+        List<ProblemResponse> content = queryFactory
+                .select(Projections.constructor(ProblemResponse.class,
+                        problem.problemId, problem.title, problem.tier, problem.solvedCount, problem.tags,
+                        record.recordId.isNotNull(),
+                         problem.difficulty.multiply(10).add(50)
+                ))
+                .from(problem)
+                .leftJoin(record).on(record.problem.eq(problem), record.user.userId.eq(userId))
+                .where(problem.problemId.between(startId, endId))
+                .orderBy(problem.solvedCount.desc()) // 인기순 정렬
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+                .orderBy(problem.solvedCount.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long total = queryFactory.select(problem.count()).from(problem)
+                .where(problem.problemId.between(startId, endId)).fetchOne();
+
+        return new PageImpl<>(content, pageable, total != null ? total : 0L);
+    }
+}

--- a/src/main/java/Coding_GO/codingGO/domain/problem/repository/impl/ProblemRepositoryCustomImpl.java
+++ b/src/main/java/Coding_GO/codingGO/domain/problem/repository/impl/ProblemRepositoryCustomImpl.java
@@ -13,6 +13,9 @@ import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
+import static Coding_GO.codingGO.domain.problem.entity.QProblemEntity.problemEntity;
+import static Coding_GO.codingGO.domain.record.entity.QStudyRecordEntity.studyRecordEntity;
+
 @Repository
 @RequiredArgsConstructor
 public class ProblemRepositoryCustomImpl implements ProblemRepositoryCustom {
@@ -27,18 +30,20 @@ public class ProblemRepositoryCustomImpl implements ProblemRepositoryCustom {
 
         List<ProblemResponse> content = queryFactory
                 .select(Projections.constructor(ProblemResponse.class,
-                        problem.problemId, problem.title, problem.tier, problem.solvedCount, problem.tags,
+                        problem.problemId,
+                        problem.title,
+                        problem.tier,
+                        problem.solvedCount,
+                        problem.tag,
                         record.recordId.isNotNull(),
                          problem.difficulty.multiply(10).add(50)
                 ))
                 .from(problem)
-                .leftJoin(record).on(record.problem.eq(problem), record.user.userId.eq(userId))
+                .leftJoin(record).on(
+                        record.problem.eq(problem),
+                        record.user.userId.eq(userId))
                 .where(problem.problemId.between(startId, endId))
                 .orderBy(problem.solvedCount.desc()) // 인기순 정렬
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .fetch();
-                .orderBy(problem.solvedCount.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();

--- a/src/main/java/Coding_GO/codingGO/domain/problem/service/ProblemService.java
+++ b/src/main/java/Coding_GO/codingGO/domain/problem/service/ProblemService.java
@@ -1,0 +1,9 @@
+package Coding_GO.codingGO.domain.problem.service;
+
+import Coding_GO.codingGO.domain.problem.presentation.data.response.ProblemResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface ProblemService {
+    Page<ProblemResponse> getProblemList(Long userId, int start, int end, Pageable pageable);
+}

--- a/src/main/java/Coding_GO/codingGO/domain/problem/service/RewardService.java
+++ b/src/main/java/Coding_GO/codingGO/domain/problem/service/RewardService.java
@@ -1,0 +1,5 @@
+package Coding_GO.codingGO.domain.problem.service;
+
+public interface RewardService {
+    void execute(Long userId);
+}

--- a/src/main/java/Coding_GO/codingGO/domain/problem/service/impl/ProblemServiceImpl.java
+++ b/src/main/java/Coding_GO/codingGO/domain/problem/service/impl/ProblemServiceImpl.java
@@ -1,0 +1,34 @@
+package Coding_GO.codingGO.domain.problem.service.impl;
+
+import Coding_GO.codingGO.domain.problem.presentation.data.response.ProblemResponse;
+import Coding_GO.codingGO.domain.problem.presentation.data.response.SolvedAcResponseDto;
+import Coding_GO.codingGO.domain.problem.repository.ProblemRepository;
+import Coding_GO.codingGO.domain.problem.service.ProblemService;
+import Coding_GO.codingGO.domain.problem.service.RewardService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+@Slf4j
+public class ProblemServiceImpl implements ProblemService {
+
+    private final ProblemRepository problemRepository;
+    private final RewardService rewardService;
+
+    @Override
+    public Page<ProblemResponse> getProblemList(Long userId, int start, int end, Pageable pageable) {
+
+        try {
+            rewardService.execute(userId);
+        } catch (Exception e) {
+            log.error("실시간 동기화 중 오류 발생 (무시하고 리스트만 반환): {}", e.getMessage());
+        }
+        return problemRepository.findAllWithUserStatus(userId, start, end, pageable);
+    }
+}

--- a/src/main/java/Coding_GO/codingGO/domain/problem/service/impl/RewardServiceImpl.java
+++ b/src/main/java/Coding_GO/codingGO/domain/problem/service/impl/RewardServiceImpl.java
@@ -1,0 +1,73 @@
+package Coding_GO.codingGO.domain.problem.service.impl;
+
+import Coding_GO.codingGO.domain.problem.entity.ProblemEntity;
+import Coding_GO.codingGO.domain.problem.repository.ProblemRepository;
+import Coding_GO.codingGO.domain.record.entity.StudyRecordEntity;
+import Coding_GO.codingGO.domain.record.repository.StudyRecordRepository;
+import Coding_GO.codingGO.domain.problem.service.RewardService;
+import Coding_GO.codingGO.global.exception.ErrorCode;
+import Coding_GO.codingGO.global.exception.GlobalException;
+import Coding_GO.codingGO.global.infra.SolvedAcClient;
+import Coding_GO.codingGO.global.infra.data.TagItem;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class RewardServiceImpl implements RewardService {
+
+    private final ProblemRepository problemRepository;
+    private final SolvedAcClient solvedAcClient;
+    private final UserRepository userRepository;
+    private final StudyRecordRepository studyRecordRepository;
+
+    @Override
+    @Transactional
+    public void execute(Long userId) {
+
+        UserEntity user = userRepository.findById(userId)
+                .orElseThrow(()-> new GlobalException(ErrorCode.USER_NOT_FOUND_EXCEPTION));
+
+        if (user.getLastSyncAt() != null &&
+                user.getLastSyncAt().isAfter(LocalDateTime.now().minusMinutes(1))) {
+            log.info("유저 {}님은 아직 쿨타임 중입니다. (최근 동기화: {})",
+                    user.getBojHandle(), user.getLastSyncAt());
+            return;
+        }
+
+        var response = solvedAcClient.search("s@" + user.getBojHandle(), 1);
+        if (response == null || response.getItems() == null) return;
+
+        for (var item : response.getItems()) {
+
+            if(!studyRecordRepository.existsByUserAndProblem_ProblemId(user,item.getProblemId())){
+
+                ProblemEntity problem = problemRepository.findById(item.getProblemId())
+                        .orElseGet(()->problemRepository.save(
+                                ProblemEntity.builder()
+                                        .problemId(item.getProblemId())
+                                        .title(item.getTitleKo())
+                                        .difficulty(item.getLevel())
+                                        .tag(String.join("," , item.getTags().stream().map(TagItem::getKey).toList()))
+                                        .build()
+                        ));
+
+                user.addPoint((problem.getDifficulty() * 10) + 50);
+
+                studyRecordRepository.save(StudyRecordEntity.builder()
+                        .user(user)
+                        .problem(problem)
+                        .isSolved(true)
+                        .solvedAt(LocalDateTime.now())
+                        .build());
+            }
+        }
+    user.updateSyncTime();
+    }
+}

--- a/src/main/java/Coding_GO/codingGO/global/config/WebConfig.java
+++ b/src/main/java/Coding_GO/codingGO/global/config/WebConfig.java
@@ -1,0 +1,13 @@
+package Coding_GO.codingGO.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebConfig {
+    @Bean
+    public WebClient.Builder webClientBuilder() {
+        return WebClient.builder();
+    }
+}

--- a/src/main/java/Coding_GO/codingGO/global/infra/SolvedAcClient.java
+++ b/src/main/java/Coding_GO/codingGO/global/infra/SolvedAcClient.java
@@ -1,0 +1,29 @@
+package Coding_GO.codingGO.global.infra;
+
+import Coding_GO.codingGO.global.infra.data.SolvedSearchResponse;
+import lombok.Getter;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Component
+public class SolvedAcClient {
+    private final WebClient webClient;
+
+    public SolvedAcClient(WebClient.Builder builder) {
+        this.webClient = builder.baseUrl("https://solved.ac/api/v3")
+                .defaultHeader(HttpHeaders.USER_AGENT, "Mozilla/5.0").build();
+    }
+
+    public SolvedSearchResponse search(String query, int page) {
+        return webClient.get()
+                .uri(uri -> uri.path("/search/problem")
+                        .queryParam("query", query)
+                        .queryParam("page", page)
+                        .build())
+                .retrieve()
+                .bodyToMono(SolvedSearchResponse.class)
+                .block();
+    }
+}
+

--- a/src/main/java/Coding_GO/codingGO/global/infra/data/ProblemItem.java
+++ b/src/main/java/Coding_GO/codingGO/global/infra/data/ProblemItem.java
@@ -9,5 +9,6 @@ public class ProblemItem {
     private Integer problemId;
     private String titleKo;
     private int level;
+    private int solvedCount;
     private List<TagItem> tags;
 }

--- a/src/main/java/Coding_GO/codingGO/global/infra/data/ProblemItem.java
+++ b/src/main/java/Coding_GO/codingGO/global/infra/data/ProblemItem.java
@@ -1,0 +1,13 @@
+package Coding_GO.codingGO.global.infra.data;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class ProblemItem {
+    private Integer problemId;
+    private String titleKo;
+    private int level;
+    private List<TagItem> tags;
+}

--- a/src/main/java/Coding_GO/codingGO/global/infra/data/SolvedSearchResponse.java
+++ b/src/main/java/Coding_GO/codingGO/global/infra/data/SolvedSearchResponse.java
@@ -1,0 +1,13 @@
+package Coding_GO.codingGO.global.infra.data;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class SolvedSearchResponse {
+    private int count;
+    private List<ProblemItem> items;
+}

--- a/src/main/java/Coding_GO/codingGO/global/infra/data/TagItem.java
+++ b/src/main/java/Coding_GO/codingGO/global/infra/data/TagItem.java
@@ -1,0 +1,10 @@
+package Coding_GO.codingGO.global.infra.data;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class TagItem {
+    private String key;
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,50 +1,44 @@
 spring:
   datasource:
-    url: jdbc:mysql://localhost:3306/codinggo?useSSL=false&serverTimezone=Asia/Seoul
-    username: root
-    password: whitekid07
+    url: ${MYSQL_URL:jdbc:mysql://localhost:3306/codinggo?useSSL=false&serverTimezone=Asia/Seoul}
+    username: ${MYSQL_USER:root}
+    password: ${MYSQL_PASSWORD:whitekid07}
     driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:
     hibernate:
-      ddl-auto: update  # create, update, validate, none ?? ??
-    show-sql: true
+      ddl-auto: ${JPA_DDL_AUTO:update}  # create, update, validate, none
+    show-sql: ${JPA_SHOW_SQL:true}
     properties:
       hibernate:
-        format_sql: true
+        format_sql: ${JPA_FORMAT_SQL:true}
 
   redis:
-    host: localhost
-    port: 6379
-
-  boot:
-    docker:
-      compose:
-        enabled: false  # Docker Compose ?? ? ?
+    host: ${REDIS_HOST:localhost}
+    port: ${REDIS_PORT:6379}
 
 server:
-  port: 8080
+  port: ${SERVER_PORT:8080}
 
 logging:
   level:
-    root: INFO
-    org.springframework.web: DEBUG
+    root: ${LOG_ROOT_LEVEL:INFO}
+    org.springframework.web: ${LOG_WEB_LEVEL:DEBUG}
+    org.ehcache: ${LOG_EHCACHE_LEVEL:DEBUG}
 
 management:
   endpoints:
     web:
       exposure:
-        include: "*"  # ?? Actuator ????? ??
+        include: ${MANAGEMENT_ENDPOINTS_INCLUDE:*}
+
 springdoc:
   api-docs:
-    path: /api-docs
+    path: ${SWAGGER_API_DOCS_PATH:/api-docs}
   swagger-ui:
-    path: /swagger-ui.html
-cache:
-  type: jcache
-  jcache:
-    config: classpath:ehcache.xml
+    path: ${SWAGGER_UI_PATH:/swagger-ui.html}
 
-    logging:
-      level:
-        org.ehcache: DEBUG
+cache:
+  type: ${CACHE_TYPE:jcache}
+  jcache:
+    config: ${JCACHE_CONFIG:classpath:ehcache.xml}


### PR DESCRIPTION
## ✨ 작업 내용
> Solved.ac API 연동을 통한 문제 리스트 조회 및 실시간 풀이 상태 동기화 구현

    실시간 데이터 동기화: /api/v1/problems API 호출 시, Solved.ac API(s@handle)를 호출하여 사용자의 최신 풀이 기록을 가져오고 포인트를 즉시 지급합니다.

    풀이 여부 확인 (isSolved): 문제 리스트 조회 시, 각 문제에 대해 해당 사용자가 풀었는지 여부를 체크하여 UI에 표시할 수 있도록 구현했습니다.

    인기순 정렬: 백준의 solvedCount 필드를 기준으로 정렬하여, 많은 사람이 푼 검증된 문제부터 노출되도록 구성했습니다.

    범위 확장: 백준의 최신 문제 번호를 수용하기 위해 조회 범위를 1,000 ~ 40,000번으로 대폭 확장했습니다.
---

## 🔍 리뷰 시 참고사항

    사용자가 리스트를 조회하는 시점에 정산 로직이 함께 실행되는 'All-in-One' 구조입니다.

    StudyRecord 테이블을 통해 중복 점수 지급을 원천 차단했습니다.

    외부 API 부하 방지를 위해 유저 엔티티의 lastSyncAt을 활용한 1분 쿨타임이 적용되어 있습니다.

문제 가져오기 / 문제의 풀이 여부 확인 을 이렇게 하는게 구현하는게 맞는지 궁금합니다.

yml 파일 환경 변수 처리함

---

## ✅ 체크리스트
- [x] 문서(README, `.env.example` 등) 변경이 필요한 경우 작성 또는 수정했나요?
- [ ] 작업한 코드가 정상적으로 동작하는 것을 직접 확인했나요?
- [ ] 필요한 경우 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] PR에 관련 없는 작업이 포함되지 않았나요?
- [x] 적절한 라벨과 리뷰어를 설정했나요?

---

## 📎 관련 이슈(선택)
- Close #
